### PR TITLE
fix(sf-bridge): use a 5-minute replication window, not 1 day, for get_deleted/get_updated

### DIFF
--- a/crates/sf-bridge/tests/integration.rs
+++ b/crates/sf-bridge/tests/integration.rs
@@ -657,13 +657,15 @@ async fn test_bridge_get_deleted() {
         return;
     };
 
-    // Use a time range from yesterday to now
+    // Use a short window (5 minutes) — on new scratch orgs, the replication
+    // date starts at org creation time, so "now - 1 day" is before the org
+    // existed and Salesforce rejects it. Matches tests/integration/rest.rs.
     let now = chrono::Utc::now();
-    let yesterday = now - chrono::Duration::days(1);
+    let start = now - chrono::Duration::minutes(5);
 
     let input = serde_json::json!({
         "sobject": "Account",
-        "start": yesterday.to_rfc3339(),
+        "start": start.to_rfc3339(),
         "end": now.to_rfc3339()
     });
 
@@ -686,13 +688,15 @@ async fn test_bridge_get_updated() {
         return;
     };
 
-    // Use a time range from yesterday to now
+    // Use a short window (5 minutes) — on new scratch orgs, the replication
+    // date starts at org creation time, so "now - 1 day" is before the org
+    // existed and Salesforce rejects it. Matches tests/integration/rest.rs.
     let now = chrono::Utc::now();
-    let yesterday = now - chrono::Duration::days(1);
+    let start = now - chrono::Duration::minutes(5);
 
     let input = serde_json::json!({
         "sobject": "Account",
-        "start": yesterday.to_rfc3339(),
+        "start": start.to_rfc3339(),
         "end": now.to_rfc3339()
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #100 (already merged) — that PR's final commit fixing this exact bug landed on the source branch *after* the PR was merged, so it never made it into `main`. This just carries that one commit forward.

`crates/sf-bridge/tests/integration.rs`'s `test_bridge_get_deleted`/`test_bridge_get_updated` used a `now - 1 day` window. On a freshly created scratch org, replication tracking starts at org-creation time, so a range starting before that gets rejected by Salesforce. This is the exact same bug the `aa9f5de` commit already fixed in `tests/integration/rest.rs` (`test_get_deleted_records`/`test_get_updated_records`) — it just never got applied to this separate test file/binary, and only surfaced once CI switched to a genuinely fresh scratch org.

Fix: use the same 5-minute window as the already-fixed root test suite. Grepped both integration test files for any other `Duration::days`/"yesterday" occurrences — none left.

## Test plan
- [x] `cargo check --workspace --all-features` (main workspace) — clean
- [x] `cargo check/clippy --all-targets --all-features -- -D warnings` (sf-bridge standalone) — clean
- [x] `cargo fmt --check` — clean
- [x] Confirmed via CI on the (now-merged) source PR that this exact fix resolved `test_bridge_get_deleted`/`test_bridge_get_updated` against the new scratch org

🤖 Generated with [Claude Code](https://claude.com/claude-code)